### PR TITLE
Add nuFAR compatibility

### DIFF
--- a/B9 PWings Fork/WingProcedural.cs
+++ b/B9 PWings Fork/WingProcedural.cs
@@ -2019,6 +2019,7 @@ namespace WingProcedural
                             if (WPDebug.logCAV)
                                 DebugLogWithID ("CalculateAerodynamicValues", "FAR/NEAR | All values set, invoking the method");
                             aeroFARMethodInfoUsed.Invoke (aeroFARModuleReference, null);
+                            part.SendMessage("GeometryPartModuleRebuildMeshData"); // for newFAR
                         }
                     }
                 }


### PR DESCRIPTION
The next version of FAR will require this message to be sent when geometry changes. It will be perfectly backwards-compatible (nothing else will 'hear' the message until nuFAR ships) so should be safe to merge.
