### PR TITLE
Configurable Containers patch

### DIFF
--- a/B9 PWings Fork/WingProcedural.cs
+++ b/B9 PWings Fork/WingProcedural.cs
@@ -704,6 +704,8 @@ namespace WingProcedural
         public static bool assemblyFARUsed = false;
         public static bool assemblyRFUsed = false;
         public static bool assemblyMFTUsed = false;
+        // if current part uses one of the Configurable Container modules
+        public bool moduleCCUsed = false;
 
         public void CheckAssemblies(bool forced)
         {
@@ -720,12 +722,20 @@ namespace WingProcedural
                         assemblyMFTUsed = true;
                 }
 
+                // check for Configurable Containers modules in this part.
+                // check for .dll cannot be used because ConfigurableContainers.dll is part of AT_Utils
+                // and is destributed without MM patches that add these modules to parts
+                moduleCCUsed = part.Modules.Contains("ModuleSwitchableTank") || part.Modules.Contains("ModuleTankManager");
+
+                // check for more than one dynamic tank mod in use
+                var mod_conflict = Convert.ToInt32(assemblyMFTUsed)+Convert.ToInt32(assemblyRFUsed)+Convert.ToInt32(moduleCCUsed);
+
                 if (HighLogic.CurrentGame.Parameters.CustomParams<WPDebug>().logEvents)
                     DebugLogWithID("CheckAssemblies", "Search results | FAR: " + assemblyFARUsed + " | RF: " + assemblyRFUsed + " | MFT: " + assemblyMFTUsed);
                 if (isCtrlSrf && isWingAsCtrlSrf && HighLogic.CurrentGame.Parameters.CustomParams<WPDebug>().logEvents)
                     DebugLogWithID("CheckAssemblies", "WARNING | PART IS CONFIGURED INCORRECTLY, BOTH BOOL PROPERTIES SHOULD NEVER BE SET TO TRUE");
-                if (assemblyRFUsed && assemblyMFTUsed && HighLogic.CurrentGame.Parameters.CustomParams<WPDebug>().logEvents)
-                    DebugLogWithID("CheckAssemblies", "WARNING | Both RF and MFT mods detected, this should not be the case");
+                if (mod_conflict > 1 && HighLogic.CurrentGame.Parameters.CustomParams<WPDebug>().logEvents)
+                    DebugLogWithID("CheckAssemblies", "WARNING | More than one of RF, MFT and CC mods detected, this should not be the case");
                 assembliesChecked = true;
             }
         }
@@ -825,7 +835,8 @@ namespace WingProcedural
 
             DeformWing();
 
-            CheckAllFieldValues(out bool updateGeo, out bool updateAero);
+            bool updateGeo, updateAero;
+            CheckAllFieldValues(out updateGeo, out updateAero);
 
             if (updateGeo)
             {
@@ -2612,7 +2623,8 @@ namespace WingProcedural
         /// <param name="allowFine">Whether right click drag behaves as fine control or not</param>
         private void DrawField(ref float field, float increment, float incrementLarge, Vector2 limits, string name, Vector4 hsbColor, int fieldID, int fieldType, bool allowFine = true)
         {
-            field = UIUtility.FieldSlider(field, increment, incrementLarge, limits, name, out bool changed, ColorHSBToRGB(hsbColor), fieldType, allowFine);
+            bool changed;
+            field = UIUtility.FieldSlider(field, increment, incrementLarge, limits, name, out changed, ColorHSBToRGB(hsbColor), fieldType, allowFine);
             if (changed)
             {
                 uiLastFieldName = name;
@@ -3120,7 +3132,8 @@ namespace WingProcedural
                 for (int i = 0; i < part.Resources.Count; ++i)
                 {
                     PartResource res = part.Resources[i];
-                    if (StaticWingGlobals.wingTankConfigurations[fuelSelectedTankSetup].resources.TryGetValue(res.resourceName, out WingTankResource wres))
+                    WingTankResource wres;
+                    if (StaticWingGlobals.wingTankConfigurations[fuelSelectedTankSetup].resources.TryGetValue(res.resourceName, out wres))
                     {
                         double fillPct = res.maxAmount > 0 ? res.amount / res.maxAmount : 1.0;
                         res.maxAmount = aeroStatVolume * StaticWingGlobals.wingTankConfigurations[fuelSelectedTankSetup].resources[res.resourceName].unitsPerVolume;
@@ -3171,19 +3184,30 @@ namespace WingProcedural
 
             if (!useStockFuel)
             {
-                PartModule module = part.Modules["ModuleFuelTanks"];
-                if (module == null)
-                    return;
+                if(assemblyRFUsed || assemblyMFTUsed)
+                {
+                    PartModule module = part.Modules["ModuleFuelTanks"];
+                    if (module == null)
+                        return;
 
-                Type type = module.GetType();
+                    Type type = module.GetType();
 
-                double volumeRF = aeroStatVolume;
-                if (assemblyRFUsed)
-                    volumeRF *= 1000;     // RF requests units in liters instead of cubic meters
-                else // assemblyMFTUsed
-                    volumeRF *= 173.9;  // MFT requests volume in units
-                type.GetField("volume").SetValue(module, volumeRF);
-                type.GetMethod("ChangeVolume").Invoke(module, new object[] { volumeRF });
+                    double volumeRF = aeroStatVolume;
+                    if (assemblyRFUsed)
+                        volumeRF *= 1000;     // RF requests units in liters instead of cubic meters
+                    else // assemblyMFTUsed
+                        volumeRF *= 173.9;  // MFT requests volume in units
+                    type.GetField("volume").SetValue(module, volumeRF);
+                    type.GetMethod("ChangeVolume").Invoke(module, new object[] { volumeRF });
+                }
+                else //moduleCCused
+                {
+                    // send public event OnPartVolumeChanged, like ProceduralParts does
+                    var data = new BaseEventDetails(BaseEventDetails.Sender.USER);
+                    data.Set<string>("volName", "Tankage");
+                    data.Set<double> ("newTotalVolume", aeroStatVolume); //aeroStatVolume should be in m3
+                    part.SendEvent("OnPartVolumeChanged", data, 0);
+                }
             }
             else
             {
@@ -3255,7 +3279,7 @@ namespace WingProcedural
         {
             get
             {
-                return !assemblyRFUsed && !assemblyMFTUsed;
+                return !(assemblyRFUsed || assemblyMFTUsed || moduleCCUsed);
             }
         }
 

--- a/GameData/B9_Aerospace_ProceduralWings/Parts/Aero_Wing_Procedural/wing_procedural_typeA.cfg
+++ b/GameData/B9_Aerospace_ProceduralWings/Parts/Aero_Wing_Procedural/wing_procedural_typeA.cfg
@@ -70,6 +70,9 @@ PART
         utilizationTweakable = true
         utilization = 0.5
         type = Default
+        
+        //see: https://github.com/search?q=tankVolumeConversion&type=Code
+        tankVolumeConversion:NEEDS[modularFuelTanks] = 200
     }
 }
 


### PR DESCRIPTION
I've added code to inform ConfigurableContainers of part volume change, so that B9-PW could also use CC tanks. MM patch to add such tanks I will maintain myself as part of CC.

I've also removed the code that propagated volume change to MFT/RF, because both support the same method as CC -- via KSPEvent system. For that to work with MFT properly I've added corresponding conversion value to config of the ModuleFuelTanks of wing typeA (as described in MFT code).

As an eye-candy, the NextConfiguration button in part menu is automatically hidden when MFT/RF/CC is used.

Last, I had to explicitly declare out variables, because Monodevelop does not support C# 7+, so no declaration expressions for me.

With CC everything is tested and works as expected. To test this with MFT/RF we need to wait until they're upgraded to KSP-1.3. Though the volume changes via KSPEvent was introduced some time ago for ProceduralParts, so it also should work.